### PR TITLE
chore: ignore python cache files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv
 .env
+__pycache__


### PR DESCRIPTION
- add pycache to gitignore to prevent commiting cache files into the repository