### PR TITLE
refactor: use datetime.now(timezone.utc) instead of deprecated datetime.utcnow()

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from chat_agent.basic_llm import get_assistant_response
 from uuid import uuid4
-from datetime import datetime
+from datetime import datetime, timezone
 from dotenv import load_dotenv
 from common.chat_models import (
     ChatRequest,
@@ -17,7 +17,7 @@ app = FastAPI()
 @app.post("/messages")
 async def messages(request: ChatRequest):
     response_id = str(uuid4())
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     assistant_response = await get_assistant_response(request.message)
     assistant_msg = Message(content=assistant_response.content, format="text")
     candidate = Candidate(


### PR DESCRIPTION
`datetime.utcnow()` is deprecated. It is recommended to use `datetime.now(timezone.utc)` instead.

![image](https://github.com/user-attachments/assets/7b03b458-3dd7-491d-a817-a920506889bc)
